### PR TITLE
zsh dependency note added in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,8 @@ building, or want to ensure that a specific version is used, you can
 modify configuration, for example to explicitly set the location of
 Tcl or MPI.
 
+**Note**: You might need to install `zsh` for a successful build. Just type `sudo apt-get install zsh`.
+
 After this initial build, you can do a quick build and install of
 all components using the fast build script:
 


### PR DESCRIPTION
I experienced a [failed build](https://gist.github.com/basheersubei/b04d6a363b2200cfcb12) on Ubuntu 14.04 which was resolved by installing `zsh` through `apt-get`. Should this be added to the README?