### PR TITLE
check for zlib on default paths first

### DIFF
--- a/lb/code/Makefile.in
+++ b/lb/code/Makefile.in
@@ -135,10 +135,12 @@ ZLIB = @ZLIB_HOME@
 
 ifeq ($(ENABLE_ZLIB),1)
   # Do not add system libraries - this can clobber the MPICH location, etc
-  ifeq ($(filter $(ZLIB_HOME)/lib,$(SYSTEM_LIBS)),)
-    CFLAGS += -I$(ZLIB)/include
-    LIBS += -L $(ZLIB)/lib
-    RPATH += -Wl,-rpath -Wl,$(ZLIB)/lib
+  ifneq ($(strip $(ZLIB)), "")
+    ifeq ($(filter $(ZLIB_HOME)/lib,$(SYSTEM_LIBS)),)
+      CFLAGS += -I$(ZLIB)/include
+      LIBS += -L $(ZLIB)/lib
+      RPATH += -Wl,-rpath -Wl,$(ZLIB)/lib
+    endif
   endif
   LIBS += -lz
 endif

--- a/lb/code/Makefile.in
+++ b/lb/code/Makefile.in
@@ -136,7 +136,7 @@ ZLIB = @ZLIB_HOME@
 ifeq ($(ENABLE_ZLIB),1)
   # Do not add system libraries - this can clobber the MPICH location, etc
   ifneq ($(strip $(ZLIB)), "")
-    ifeq ($(filter $(ZLIB_HOME)/lib,$(SYSTEM_LIBS)),)
+    ifeq ($(filter $(ZLIB)/lib,$(SYSTEM_LIBS)),)
       CFLAGS += -I$(ZLIB)/include
       LIBS += -L $(ZLIB)/lib
       RPATH += -Wl,-rpath -Wl,$(ZLIB)/lib

--- a/lb/code/configure.ac
+++ b/lb/code/configure.ac
@@ -250,16 +250,11 @@ AC_SUBST(XLB_ENABLE_XPT)
 if [[ ${XLB_ENABLE_XPT} == yes ]]
 then
   ENABLE_ZLIB=0
-  ZLIB_HOME=0
+  ZLIB_HOME=
   AC_FUNC_FSEEKO
   m4_include([../../dev/m4/ax_check_zlib.m4])
   AX_CHECK_ZLIB([ENABLE_ZLIB=1],
                 AC_MSG_ERROR([Could not find zlib! (required for checkpoint)]))
-  # Check that we got a sensible location
-  if [[ ! -d "$ZLIB_HOME" ]]
-  then
-    AC_MSG_ERROR([Could not find zlib! (required for checkpoint)])
-  fi
 fi
 AC_SUBST(ZLIB_HOME)
 AC_SUBST(ENABLE_ZLIB)

--- a/turbine/code/Makefile.in
+++ b/turbine/code/Makefile.in
@@ -245,7 +245,7 @@ USE_COASTER  = @USE_COASTER@
 
 # Record ZLIB setting in comments for debugging:
 ENABLE_ZLIB = @ENABLE_ZLIB@
-ZLIB_HOME = @ZLIB_HOME@
+ZLIB = @ZLIB_HOME@
 
 CFLAGS += $(STD)
 CFLAGS += -g
@@ -275,10 +275,10 @@ ifeq ($(HAVE_COASTER),1)
 	INCLUDES += -I $(USE_COASTER)/include
 endif
 ifeq ($(ENABLE_ZLIB),1)
-  ifneq ($(strip $(ZLIB_HOME)), "")
-    ifeq ($(filter $(ZLIB_HOME)/lib,$(SYSTEM_LIBS)),)
-      INCLUDES += -I $(ZLIB_HOME)/include
-      LIBS += -L $(ZLIB_HOME)/lib
+  ifneq ($(strip $(ZLIB)), "")
+    ifeq ($(filter $(ZLIB)/lib,$(SYSTEM_LIBS)),)
+      INCLUDES += -I $(ZLIB)/include
+      LIBS += -L $(ZLIB)/lib
       RPATH += -Wl,-rpath -Wl,$(ZLIB)/lib
     endif
   endif

--- a/turbine/code/Makefile.in
+++ b/turbine/code/Makefile.in
@@ -275,10 +275,12 @@ ifeq ($(HAVE_COASTER),1)
 	INCLUDES += -I $(USE_COASTER)/include
 endif
 ifeq ($(ENABLE_ZLIB),1)
-  ifeq ($(filter $(ZLIB_HOME)/lib,$(SYSTEM_LIBS)),)
-    INCLUDES += -I $(ZLIB_HOME)/include
-    LIBS += -L $(ZLIB_HOME)/lib
-    RPATH += -Wl,-rpath -Wl,$(ZLIB)/lib
+  ifneq ($(strip $(ZLIB_HOME)), "")
+    ifeq ($(filter $(ZLIB_HOME)/lib,$(SYSTEM_LIBS)),)
+      INCLUDES += -I $(ZLIB_HOME)/include
+      LIBS += -L $(ZLIB_HOME)/lib
+      RPATH += -Wl,-rpath -Wl,$(ZLIB)/lib
+    endif
   endif
   LIBS += -lz
 endif


### PR DESCRIPTION
PR does the following (in response to #68):
  1. Modifies AX_CHECK_ZLIB to search default system paths if a custom witharg is not set by the user, falling back to the directory walk approach if witharg is a directory or if the initial search fails.
  2. Updates the build files to be more permissive on an empty ZLIB_HOME
This should prevent system paths from being put in user search paths (-I, -L).

I've tested with and without `DISABLE_ZLIB`. However, zlib is on my system path so I haven't been able to test fully. Anyone with weird zlib installs want to give this a try?