### PR TITLE
Avoid divide-by-zero in loop unrolling pass

### DIFF
--- a/stc/code/src/exm/stc/ic/tree/ForeachLoops.java
+++ b/stc/code/src/exm/stc/ic/tree/ForeachLoops.java
@@ -788,6 +788,11 @@ public class ForeachLoops {
       } else if (expandLoops || fullUnroll) {
         long instCount = loopBody.getInstructionCount();
         long iterCount = constIterCount();
+
+        if (instCount == 0) {
+          return NO_UNROLL;
+        }
+
         if (expandLoops && iterCount >= 0) {
           // See if the loop has a small number of iterations, could just expand;
           if (iterCount <= getUnrollMaxIters(true)) {


### PR DESCRIPTION
See github issue #98