### PR TITLE
fix include path for python 2.7

### DIFF
--- a/turbine/code/scripts/python-config.py
+++ b/turbine/code/scripts/python-config.py
@@ -31,9 +31,9 @@ def get_lib_name():
 
 def get_config_value(name):
     if name == 'include-dir':
-        value = sysconfig.get_path('include')
+        value = sysconfig.get_config_var('INCLUDEPY')
     elif name == 'include-flags':
-        value = '-I' + sysconfig.get_path('include')
+        value = '-I' + sysconfig.get_config_var('INCLUDEPY')
     elif name == 'lib-dir':
         value = sysconfig.get_config_var('LIBDIR')
     elif name == 'lib-name':


### PR DESCRIPTION
For some reason sysconfig.get_path('include') returns a wrong
value on debian/ubuntu python 2.7. The INCLUDEPY config var
appears to always be the correct value.