### PR TITLE
Update tcl-python.c

### DIFF
--- a/turbine/code/src/tcl/python/tcl-python.c
+++ b/turbine/code/src/tcl/python/tcl-python.c
@@ -33,6 +33,8 @@
 #include "Python.h"
 #endif
 
+#include <dlfcn.h>
+
 #include <stdio.h>
 
 #include <tcl.h>
@@ -88,6 +90,19 @@ static bool initialized = false;
 
 static int python_init(void)
 {
+/* Loading python library symbols so that dynamic extensions don't throw symbol not found error.           
+           Ref Link: http://stackoverflow.com/questions/29880931/importerror-and-pyexc-systemerror-while-embedding-python-script-within-c-for-pam
+        */
+  char str_python_lib[17];
+#ifdef _WIN32
+  sprintf(str_python_lib, "libpython%d.%d.dll", PY_MAJOR_VERSION, PY_MINOR_VERSION);
+#elif defined __unix__
+  sprintf(str_python_lib, "libpython%d.%d.so", PY_MAJOR_VERSION, PY_MINOR_VERSION);
+#elif defined __APPLE__
+  sprintf(str_python_lib, "libpython%d.%d.dylib", PY_MAJOR_VERSION, PY_MINOR_VERSION);
+#endif
+  dlopen(str_python_lib, RTLD_NOW | RTLD_GLOBAL);
+
   if (initialized) return TCL_OK;
   DEBUG_TCL_TURBINE("python: initializing...");
   Py_InitializeEx(1);


### PR DESCRIPTION
o Fix ImportError and PyExc_SystemError, when importing numpy (Ubuntu 16.04)

===
ImportError: 
Importing the multiarray numpy extension module failed.  Most
likely you are trying to import a failed build of numpy.
If you're working with a numpy git repo, try `git clean -xdf` (removes all
files not under version control).  Otherwise reinstall numpy.

Original error was: /usr/local/lib/python2.7/dist-packages/numpy-1.14.0.dev0+d0c15fa-py2.7-linux-x86_64.egg/numpy/core/multiarray.so: undefined symbol: PyExc_SystemError

