### PR TITLE
Use #!/usr/bin/env zsh to avoid problems on systems where zsh cannot be installed as root

### DIFF
--- a/c-utils/code/maint/file-list.zsh
+++ b/c-utils/code/maint/file-list.zsh
@@ -1,4 +1,4 @@
-#!/bin/zsh -f
+#!/usr/bin/env zsh -f
 set -eu
 
 # FILE LIST

--- a/dev/debian/make-debs.zsh
+++ b/dev/debian/make-debs.zsh
@@ -1,4 +1,4 @@
-#!/bin/zsh -f
+#!/usr/bin/env zsh -f
 set -eu
 
 # MAKE DEBS

--- a/dev/release/make-release-pkg.zsh
+++ b/dev/release/make-release-pkg.zsh
@@ -1,4 +1,4 @@
-#!/bin/zsh -f
+#!/usr/bin/env zsh -f
 set -eu
 
 # MAKE-RELEASE-PKG.ZSH

--- a/lb/code/maint/file-list.zsh
+++ b/lb/code/maint/file-list.zsh
@@ -1,4 +1,4 @@
-#!/bin/zsh -f
+#!/usr/bin/env zsh -f
 set -eu
 
 # ADLB/X FILE LIST

--- a/lb/code/maint/jenkins.zsh
+++ b/lb/code/maint/jenkins.zsh
@@ -1,4 +1,4 @@
-#!/bin/zsh
+#!/usr/bin/env zsh
 
 # ADLB JENKINS.ZSH
 # Run on the Jenkins server

--- a/stc/bench/foreach-1D/foreach.zsh
+++ b/stc/bench/foreach-1D/foreach.zsh
@@ -1,4 +1,4 @@
-#!/bin/zsh
+#!/usr/bin/env zsh
 
 PROGRAM_SWIFT="foreach.swift"
 PROGRAM_TCL=${PROGRAM_SWIFT%.swift}.tcl

--- a/stc/bench/foreach-1D/plot-completions.zsh
+++ b/stc/bench/foreach-1D/plot-completions.zsh
@@ -1,4 +1,4 @@
-#!/bin/zsh
+#!/usr/bin/env zsh
 
 EXM=${HOME}/exm
 

--- a/stc/bench/foreach-2D/foreach.zsh
+++ b/stc/bench/foreach-2D/foreach.zsh
@@ -1,4 +1,4 @@
-#!/bin/zsh
+#!/usr/bin/env zsh
 
 PROGRAM_SWIFT="foreach.swift"
 PROGRAM_TCL=${PROGRAM_SWIFT%.swift}.tcl

--- a/stc/bench/foreach-sum/foreach.zsh
+++ b/stc/bench/foreach-sum/foreach.zsh
@@ -1,4 +1,4 @@
-#!/bin/zsh
+#!/usr/bin/env zsh
 
 PROGRAM_SWIFT="foreach.swift"
 PROGRAM_TCL=${PROGRAM_SWIFT%.swift}.tcl

--- a/stc/bench/foreach-sum/plot-completions.zsh
+++ b/stc/bench/foreach-sum/plot-completions.zsh
@@ -1,4 +1,4 @@
-#!/bin/zsh
+#!/usr/bin/env zsh
 
 EXM=${HOME}/exm
 

--- a/stc/bench/fs/chirp-scripts/bb-start-servers.zsh
+++ b/stc/bench/fs/chirp-scripts/bb-start-servers.zsh
@@ -1,4 +1,4 @@
-#!/bin/zsh
+#!/usr/bin/env zsh
 
 # Start Chirp servers on all allocated Breadboard nodes
 

--- a/stc/bench/fs/chirp-scripts/bb-stop-servers.zsh
+++ b/stc/bench/fs/chirp-scripts/bb-stop-servers.zsh
@@ -1,4 +1,4 @@
-#!/bin/zsh
+#!/usr/bin/env zsh
 
 # Start Chirp servers on all allocated Breadboard nodes
 

--- a/stc/bench/fs/chirp-scripts/local-server.zsh
+++ b/stc/bench/fs/chirp-scripts/local-server.zsh
@@ -1,4 +1,4 @@
-#!/bin/zsh
+#!/usr/bin/env zsh
 
 # Start a local Chirp server
 

--- a/stc/bench/fs/creates/sh-sleep.zsh
+++ b/stc/bench/fs/creates/sh-sleep.zsh
@@ -1,4 +1,4 @@
-#!/bin/zsh
+#!/usr/bin/env zsh
 
 # Reference measurement
 

--- a/stc/bench/fs/creates/sh-touch.zsh
+++ b/stc/bench/fs/creates/sh-touch.zsh
@@ -1,4 +1,4 @@
-#!/bin/zsh
+#!/usr/bin/env zsh
 
 # Reference measurement
 

--- a/stc/bench/loops/loops.zsh
+++ b/stc/bench/loops/loops.zsh
@@ -1,4 +1,4 @@
-#!/bin/zsh
+#!/usr/bin/env zsh
 
 PROGRAM_SWIFT="loops.swift"
 PROGRAM_TCL=${PROGRAM_SWIFT%.swift}.tcl

--- a/stc/bench/wavefront/wavefront.zsh
+++ b/stc/bench/wavefront/wavefront.zsh
@@ -1,4 +1,4 @@
-#!/bin/zsh
+#!/usr/bin/env zsh
 
 PROGRAM_SWIFT="wavefront.swift"
 PROGRAM_TCL=${PROGRAM_SWIFT%.swift}.tcl

--- a/stc/code/bin/stc
+++ b/stc/code/bin/stc
@@ -1,4 +1,4 @@
-#!/bin/zsh -f
+#!/usr/bin/env zsh -f
 set -eu
 
 # STC: Swift-Turbine Compiler

--- a/stc/code/bin/stc-debug
+++ b/stc/code/bin/stc-debug
@@ -1,4 +1,4 @@
-#!/bin/zsh -eu
+#!/usr/bin/env zsh -eu
 
 TCLSH=""
 

--- a/stc/code/bin/swift-t
+++ b/stc/code/bin/swift-t
@@ -1,4 +1,4 @@
-#!/bin/zsh -f
+#!/usr/bin/env zsh -f
 set -eu
 
 # SWIFT-T

--- a/stc/code/maint/file-list.zsh
+++ b/stc/code/maint/file-list.zsh
@@ -1,4 +1,4 @@
-#!/bin/zsh -f
+#!/usr/bin/env zsh -f
 set -eu
 
 # STC FILE LIST

--- a/stc/tests/705-split.check.sh
+++ b/stc/tests/705-split.check.sh
@@ -1,4 +1,4 @@
-#!/bin/zsh
+#!/usr/bin/env zsh
 
 set -x
 

--- a/stc/tests/jenkins-results.zsh
+++ b/stc/tests/jenkins-results.zsh
@@ -1,4 +1,4 @@
-#!/bin/zsh
+#!/usr/bin/env zsh
 
 # STC TESTS JENKINS-RESULTS.ZSH
 

--- a/stc/tests/jenkins.zsh
+++ b/stc/tests/jenkins.zsh
@@ -1,4 +1,4 @@
-#!/bin/zsh
+#!/usr/bin/env zsh
 set -eu
 
 # STC TESTS JENKINS.ZSH

--- a/stc/tests/run-test.zsh
+++ b/stc/tests/run-test.zsh
@@ -1,4 +1,4 @@
-#!/bin/zsh -f
+#!/usr/bin/env zsh -f
 set -eu
 
 # usage: run-test <OPTIONS> <PROGRAM> <OUTPUT>

--- a/stc/tests/run-tests.zsh
+++ b/stc/tests/run-tests.zsh
@@ -1,4 +1,4 @@
-#!/bin/zsh -f
+#!/usr/bin/env zsh -f
 set -eu
 
 # STC RUN-TESTS

--- a/turbine/code/bin/turbine.in
+++ b/turbine/code/bin/turbine.in
@@ -1,4 +1,4 @@
-#!/bin/zsh -f
+#!/usr/bin/env zsh -f
 # We use zsh -f to avoid reloading user startup files and
 # resetting environment, e.g., LD_LIBRARY_PATH.
 

--- a/turbine/code/maint/file-list.zsh
+++ b/turbine/code/maint/file-list.zsh
@@ -1,4 +1,4 @@
-#!/bin/zsh -f
+#!/usr/bin/env zsh -f
 set -eu
 
 # TURBINE FILE LIST

--- a/turbine/code/maint/jenkins-tests.zsh
+++ b/turbine/code/maint/jenkins-tests.zsh
@@ -1,4 +1,4 @@
-#!/bin/zsh
+#!/usr/bin/env zsh
 
 # Jenkins script - run Turbine test suite
 

--- a/turbine/code/maint/jenkins.sh
+++ b/turbine/code/maint/jenkins.sh
@@ -1,4 +1,4 @@
-#!/bin/zsh
+#!/usr/bin/env zsh
 set -eu
 
 # Turbine Jenkins script - build only

--- a/turbine/code/scripts/rank.zsh
+++ b/turbine/code/scripts/rank.zsh
@@ -1,4 +1,4 @@
-#!/bin/zsh
+#!/usr/bin/env zsh
 # Copyright 2013 University of Chicago and Argonne National Laboratory
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/turbine/code/scripts/submit/cobalt/turbine-cobalt-run.zsh
+++ b/turbine/code/scripts/submit/cobalt/turbine-cobalt-run.zsh
@@ -1,4 +1,4 @@
-#!/bin/zsh -f
+#!/usr/bin/env zsh -f
 set -eu
 
 # Copyright 2013 University of Chicago and Argonne National Laboratory

--- a/turbine/code/scripts/submit/cray/gemtc/turbine-aprun-run.zsh
+++ b/turbine/code/scripts/submit/cray/gemtc/turbine-aprun-run.zsh
@@ -1,4 +1,4 @@
-#!/bin/zsh -ef
+#!/usr/bin/env zsh -ef
 
 # Copyright 2013 University of Chicago and Argonne National Laboratory
 #

--- a/turbine/code/scripts/submit/cray/turbine-cray-run.zsh
+++ b/turbine/code/scripts/submit/cray/turbine-cray-run.zsh
@@ -1,4 +1,4 @@
-#!/bin/zsh -f
+#!/usr/bin/env zsh -f
 set -eu
 
 # Copyright 2013 University of Chicago and Argonne National Laboratory

--- a/turbine/code/scripts/submit/ec2/turbine-setup-ec2.zsh
+++ b/turbine/code/scripts/submit/ec2/turbine-setup-ec2.zsh
@@ -1,4 +1,4 @@
-#!/bin/zsh
+#!/usr/bin/env zsh
 # Copyright 2013 University of Chicago and Argonne National Laboratory
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/turbine/code/scripts/submit/lsf/turbine-lsf-run.zsh
+++ b/turbine/code/scripts/submit/lsf/turbine-lsf-run.zsh
@@ -1,4 +1,4 @@
-#!/bin/zsh -f
+#!/usr/bin/env zsh -f
 set -eu
 
 # Copyright 2013 University of Chicago and Argonne National Laboratory

--- a/turbine/code/scripts/submit/pbs/turbine-pbs-run.zsh
+++ b/turbine/code/scripts/submit/pbs/turbine-pbs-run.zsh
@@ -1,4 +1,4 @@
-#!/bin/zsh -f
+#!/usr/bin/env zsh -f
 set -eu
 
 # Copyright 2013 University of Chicago and Argonne National Laboratory

--- a/turbine/code/scripts/submit/sge/turbine-sge-run.zsh
+++ b/turbine/code/scripts/submit/sge/turbine-sge-run.zsh
@@ -1,4 +1,4 @@
-#!/bin/zsh -f
+#!/usr/bin/env zsh -f
 set -eu
 
 # Copyright 2013 University of Chicago and Argonne National Laboratory

--- a/turbine/code/scripts/submit/slurm/turbine-slurm-run.zsh
+++ b/turbine/code/scripts/submit/slurm/turbine-slurm-run.zsh
@@ -1,4 +1,4 @@
-#!/bin/zsh
+#!/usr/bin/env zsh
 set -eu
 
 # Copyright 2013 University of Chicago and Argonne National Laboratory

--- a/turbine/code/scripts/submit/theta/turbine-theta-run.zsh
+++ b/turbine/code/scripts/submit/theta/turbine-theta-run.zsh
@@ -1,4 +1,4 @@
-#!/bin/zsh -f
+#!/usr/bin/env zsh -f
 set -eu
 
 # Copyright 2013 University of Chicago and Argonne National Laboratory

--- a/turbine/code/scripts/submit/turbine-output-list.zsh
+++ b/turbine/code/scripts/submit/turbine-output-list.zsh
@@ -1,4 +1,4 @@
-#!/bin/zsh
+#!/usr/bin/env zsh
 # Copyright 2013 University of Chicago and Argonne National Laboratory
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/turbine/code/scripts/submit/turbine-output-search.zsh
+++ b/turbine/code/scripts/submit/turbine-output-search.zsh
@@ -1,4 +1,4 @@
-#!/bin/zsh
+#!/usr/bin/env zsh
 # Copyright 2013 University of Chicago and Argonne National Laboratory
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/turbine/code/tests/bench.zsh
+++ b/turbine/code/tests/bench.zsh
@@ -1,4 +1,4 @@
-#!/bin/zsh
+#!/usr/bin/env zsh
 # Copyright 2013 University of Chicago and Argonne National Laboratory
 #
 # Licensed under the Apache License, Version 2.0 (the "License");


### PR DESCRIPTION
zsh cannot always be installed as root. On such systems, it is currently a pain to build and run Swift/T. This patch uses `/usr/bin/env` in `#!` lines to make sure that we can find `zsh` on `PATH` even if it is not installed in the default location on the system.