### PR TITLE
BLD: fix missing vars in internal-build-all.sh

### DIFF
--- a/dev/build/internal-build-all.sh
+++ b/dev/build/internal-build-all.sh
@@ -7,6 +7,7 @@ THIS=$( cd $(dirname $0) && /bin/pwd )
 
 ${THIS}/check-tools.sh
 source ${THIS}/functions.sh
+source ${THIS}/options.sh
 
 LOG $LOG_INFO ""
 ${THIS}/build-cutils.sh


### PR DESCRIPTION
This PR fixes the situation when no variables are set in the user's env, e.g., `VERBOSITY`, which was missing during execution of `internal-build-all.sh`:
```bash
$ ./internal-build-all.sh
/home/vagrant/src/mrakitin/swift-t/dev/build/functions.sh: line 37: VERBOSITY: unbound variable
```