### PR TITLE
Fixes issue 151

### DIFF
--- a/turbine/code/configure.ac
+++ b/turbine/code/configure.ac
@@ -655,6 +655,7 @@ then
     AC_SUBST(PYTHON_LIB_FLAGS)
     AC_SUBST(PYTHON_LIBDIR)
     AC_SUBST(PYTHON_NAME)
+    AC_DEFINE_UNQUOTED([PYTHON_NAME],"$PYTHON_NAME",[Provides Python Name])
 else
     AC_MSG_RESULT([Python disabled])
 fi

--- a/turbine/code/src/tcl/python/tcl-python.c
+++ b/turbine/code/src/tcl/python/tcl-python.c
@@ -90,16 +90,16 @@ static bool initialized = false;
 
 static int python_init(void)
 {
-/* Loading python library symbols so that dynamic extensions don't throw symbol not found error.           
+/* Loading python library symbols so that dynamic extensions don't throw symbol not found error.
            Ref Link: http://stackoverflow.com/questions/29880931/importerror-and-pyexc-systemerror-while-embedding-python-script-within-c-for-pam
         */
-  char str_python_lib[17];
+  char str_python_lib[32];
 #ifdef _WIN32
-  sprintf(str_python_lib, "libpython%d.%d.dll", PY_MAJOR_VERSION, PY_MINOR_VERSION);
+  sprintf(str_python_lib, "lib%s.dll", PYTHON_NAME);
 #elif defined __unix__
-  sprintf(str_python_lib, "libpython%d.%d.so", PY_MAJOR_VERSION, PY_MINOR_VERSION);
+  sprintf(str_python_lib, "lib%s.so", PYTHON_NAME);
 #elif defined __APPLE__
-  sprintf(str_python_lib, "libpython%d.%d.dylib", PY_MAJOR_VERSION, PY_MINOR_VERSION);
+  sprintf(str_python_lib, "lib%s.dylib", PYTHON_NAME);
 #endif
   dlopen(str_python_lib, RTLD_NOW | RTLD_GLOBAL);
 


### PR DESCRIPTION
Fix for [Issue 151](https://github.com/swift-lang/swift-t/issues/151) -- uses PYTHON_NAME to correctly construct the python library name. PYTHON_NAME is defined in config.h via configure.ac