### PR TITLE
tweak build tests to work on IBM CORAL systems

### DIFF
--- a/lb/code/configure.ac
+++ b/lb/code/configure.ac
@@ -218,22 +218,18 @@ AC_ARG_ENABLE(mpi-2,
 AC_DEFINE_UNQUOTED(ADLB_MPI_VERSION, [${ADLB_MPI_VERSION}],
                    [MPI version])
 
-AC_MSG_CHECKING([MPI version])
-${CC} -E -P ${CFLAGS} maint/mpi_version.c > mpi_version.c.txt
-[[ ${?} != 0 ]] && AC_MSG_ERROR([Could not preprocess maint/mpi_version.c])
-
-MPI_VERSION_LINE=$( grep "The MPI version is" mpi_version.c.txt )
-AC_MSG_RESULT([${MPI_VERSION_LINE}])
-MPI_VERSION=$( echo ${MPI_VERSION_LINE} | cut -d ' ' -f 5 )
+# if user wants to build with MPI 3,
+# check the reported MPI_VERSION number
 if [[ ${ADLB_MPI_VERSION} == 3 ]]
 then
-   [[ ${MPI_VERSION} == 3 ]] || \
-     AC_MSG_ERROR([MPI_VERSION 3 is required for parallel tasks!
+AC_MSG_CHECKING([MPI version])
+${CC} ${CFLAGS} -o maint/mpi_version3_test maint/mpi_version3_test.c
+[[ ${?} != 0 ]] && AC_MSG_ERROR([MPI_VERSION 3 is required for parallel tasks!
                    You must 1) re-configure with --enable-mpi-2
                                which disables parallel tasks; or
                             2) use an MPI 3 implementation])
+rm -f maint/mpi_version3_test
 fi
-rm -f mpi_version.c.txt
 
 XLB_ENABLE_XPT=no
 AC_ARG_ENABLE(checkpoint,

--- a/lb/code/maint/mpi_version3_test.c
+++ b/lb/code/maint/mpi_version3_test.c
@@ -1,0 +1,7 @@
+#include "mpi.h"
+
+#if MPI_VERSION < 3
+#error "MPI_VERSION 3 or greater required!"
+#endif
+
+int main(int argc, char** argv) { return 0; }

--- a/turbine/code/configure.ac
+++ b/turbine/code/configure.ac
@@ -391,7 +391,7 @@ fi
 
 if [[ -z "${USE_MPI_LIB_NAME}" ]]
 then
-  MPI_LIB_NAME_ALTS="mpi mpich"
+  MPI_LIB_NAME_ALTS="mpi mpich mpi_ibm"
 else
   MPI_LIB_NAME_ALTS="${USE_MPI_LIB_NAME}"
 fi

--- a/turbine/code/scripts/submit/lsf/turbine-lsf-run.zsh
+++ b/turbine/code/scripts/submit/lsf/turbine-lsf-run.zsh
@@ -44,7 +44,7 @@ TURBINE_LSF=${TURBINE_OUTPUT}/turbine-lsf.sh
 m4 ${COMMON_M4} ${TURBINE_LSF_M4} > ${TURBINE_LSF}
 print "wrote: ${TURBINE_LSF}"
 
-BSUB=/sw/sources/lsf-tools/2.0/summit/bin/bsub
+BSUB=bsub
 
 cd ${TURBINE_OUTPUT:A} # Canonicalize
 echo "PWD: ${PWD}"


### PR DESCRIPTION
For building IBM's mpicc on IBM CORAL systems, which uses xlc and links to IBM's MPI:
* adds mpi_ibm as an alternative MPI library name in the turbine configure
* changes test of MPI_VERSION from a preprocessor test to a compile test, since xlc writes preprocessor output to a different filename than expected