### PR TITLE
Tell SWIG to use Tcl for python and launch

### DIFF
--- a/turbine/code/src/tcl/launch/module.mk.in
+++ b/turbine/code/src/tcl/launch/module.mk.in
@@ -17,7 +17,7 @@ endif
 
 $(SWIG_C_FILE_LAUNCH): $(DIR)/launch.i $(DIR)/launch.h
 	$(Q) "  SWIG 		$(<)"
-	$(E) swig -outdir $(DIR) $(<)
+	$(E) swig -tcl -outdir $(DIR) $(<)
 
 clean::
 	$(Q) "  CLEAN $(DIR)"

--- a/turbine/code/src/tcl/python/module.mk.in
+++ b/turbine/code/src/tcl/python/module.mk.in
@@ -12,7 +12,7 @@ SWIG_C_FILE_PYTHON = $(DIR)/python-swig_wrap.c
 
 $(SWIG_C_FILE_PYTHON): $(DIR)/python-swig.i $(DIR)/python-swig.h
 	$(Q) "  SWIG 		$(<)"
-	$(E) swig -outdir $(DIR) $(<)
+	$(E) swig -tcl -outdir $(DIR) $(<)
 
 clean::
 	$(Q) "  CLEAN $(DIR)"


### PR DESCRIPTION
Adds '-tcl' to use swig in the module.mk.in files for the python and launch sources