### PR TITLE
Changed SBATCH option in turbine-slurm.sh.m4 from --workdir to -D sin…

### DIFF
--- a/turbine/code/scripts/submit/slurm/turbine-slurm.sh.m4
+++ b/turbine/code/scripts/submit/slurm/turbine-slurm.sh.m4
@@ -36,7 +36,7 @@ ifelse(getenv_nospace(PROJECT),`',,
 #SBATCH --time=getenv_nospace(WALLTIME)
 #SBATCH --nodes=getenv_nospace(NODES)
 #SBATCH --ntasks-per-node=getenv_nospace(PPN)
-#SBATCH --workdir=getenv_nospace(TURBINE_OUTPUT)
+#SBATCH -D getenv_nospace(TURBINE_OUTPUT)
 
 # M4 conditional to optionally perform user email notifications
 ifelse(getenv_nospace(MAIL_ENABLED),`1',


### PR DESCRIPTION
…ce --workdir is deprecated and -D should work in both old and new versions of SLURM