### PR TITLE
Fix hard-coded path for zsh

### DIFF
--- a/dev/build/lock.sh
+++ b/dev/build/lock.sh
@@ -1,4 +1,4 @@
-#!/bin/zsh
+#!/usr/bin/env zsh
 set -eu
 
 # LOCK SH


### PR DESCRIPTION
This is part one of a fix for #193.